### PR TITLE
Always add #success to response from #hlr

### DIFF
--- a/lib/sms_aero/operations/hlr.rb
+++ b/lib/sms_aero/operations/hlr.rb
@@ -16,6 +16,10 @@ class SmsAero
       attribute :id, proc(&:to_s)
       attribute :success, default: proc { id != "" }
     end
+
+    response :failure, 200, format: :json, model: Answer do
+      attribute :success, default: proc { false }
+    end
   end
 
   operation :hlr_status do

--- a/spec/sms_aero/operations/hlr_spec.rb
+++ b/spec/sms_aero/operations/hlr_spec.rb
@@ -40,6 +40,14 @@ describe SmsAero do
         expect { subject }.to raise_error(ArgumentError)
       end
     end
+
+    context "when rejected" do
+      let(:answer) { { result: "rejected" } }
+
+      it "has success false" do
+        expect(subject.success).to be_falsey
+      end
+    end
   end
 
   describe "#hlr_status" do


### PR DESCRIPTION
After using HLR status requests, I faced with problem that for some numbers (e.g. Ukrainian) sending HLR request is not successed (and we will not have `id` to pass it to `#hlr_status`).

So, I add second rule to parse response from `#hlr` and make `success` method to be available anyway. It is realized in v0.1.2 by `#success?` method, but I miss this in v0.0.10 :)